### PR TITLE
Automatic update of BoltOn to 0.18.1

### DIFF
--- a/samples/BoltOn.Overrides/BoltOn.Overrides.csproj
+++ b/samples/BoltOn.Overrides/BoltOn.Overrides.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="BoltOn" Version="0.18.0" />
+    <PackageReference Include="BoltOn" Version="0.18.1" />
     <PackageReference Include="BoltOn.Data.EF" Version="0.11.0" />
   </ItemGroup>
   <ItemGroup>

--- a/samples/BoltOn.Samples.Application/BoltOn.Samples.Application.csproj
+++ b/samples/BoltOn.Samples.Application/BoltOn.Samples.Application.csproj
@@ -15,7 +15,7 @@
         <Folder Include="Entities\" />
     </ItemGroup>
     <ItemGroup>
-        <PackageReference Include="BoltOn" Version="0.18.0" />
+        <PackageReference Include="BoltOn" Version="0.18.1" />
         <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
         <PackageReference Include="Microsoft.Azure.DocumentDB.Core" Version="2.9.3" />
     </ItemGroup>

--- a/samples/BoltOn.Samples.Console/BoltOn.Samples.Console.csproj
+++ b/samples/BoltOn.Samples.Console/BoltOn.Samples.Console.csproj
@@ -30,7 +30,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="BoltOn" Version="0.18.0" />
+    <PackageReference Include="BoltOn" Version="0.18.1" />
     <PackageReference Include="BoltOn.Data.EF" Version="0.11.0" />
     <PackageReference Include="BoltOn.Data.CosmosDb" Version="0.7.0" />
     <PackageReference Include="BoltOn.Bus.MassTransit" Version="0.7.0" />

--- a/samples/BoltOn.Samples.Infrastructure/BoltOn.Samples.Infrastructure.csproj
+++ b/samples/BoltOn.Samples.Infrastructure/BoltOn.Samples.Infrastructure.csproj
@@ -19,7 +19,7 @@
         <Folder Include="Data\Mappings\" />
     </ItemGroup>
     <ItemGroup>
-        <PackageReference Include="BoltOn" Version="0.18.0" />
+        <PackageReference Include="BoltOn" Version="0.18.1" />
         <PackageReference Include="BoltOn.Data.EF" Version="0.11.0" />
         <PackageReference Include="BoltOn.Data.CosmosDb" Version="0.7.0" />
         <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.1.2" />

--- a/samples/BoltOn.Samples.WebApi/BoltOn.Samples.WebApi.csproj
+++ b/samples/BoltOn.Samples.WebApi/BoltOn.Samples.WebApi.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="BoltOn" Version="0.18.0" />
+    <PackageReference Include="BoltOn" Version="0.18.1" />
     <PackageReference Include="BoltOn.Data.EF" Version="0.11.0" />
     <PackageReference Include="BoltOn.Data.CosmosDb" Version="0.7.0" />
     <PackageReference Include="BoltOn.Bus.MassTransit" Version="0.7.0" />

--- a/src/BoltOn.Templates/templates/WebApiTemplate/WebApiTemplate.csproj
+++ b/src/BoltOn.Templates/templates/WebApiTemplate/WebApiTemplate.csproj
@@ -3,6 +3,6 @@
     <TargetFramework>netcoreapp3.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="BoltOn" Version="0.18.0" />
+    <PackageReference Include="BoltOn" Version="0.18.1" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
NuKeeper has generated a patch update of `BoltOn` to `0.18.1` from `0.18.0`
`BoltOn 0.18.1` was published at `2020-02-29T15:34:08Z`, 10 days ago

6 project updates:
Updated `samples\BoltOn.Overrides\BoltOn.Overrides.csproj` to `BoltOn` `0.18.1` from `0.18.0`
Updated `samples\BoltOn.Samples.Application\BoltOn.Samples.Application.csproj` to `BoltOn` `0.18.1` from `0.18.0`
Updated `samples\BoltOn.Samples.Console\BoltOn.Samples.Console.csproj` to `BoltOn` `0.18.1` from `0.18.0`
Updated `samples\BoltOn.Samples.Infrastructure\BoltOn.Samples.Infrastructure.csproj` to `BoltOn` `0.18.1` from `0.18.0`
Updated `samples\BoltOn.Samples.WebApi\BoltOn.Samples.WebApi.csproj` to `BoltOn` `0.18.1` from `0.18.0`
Updated `src\BoltOn.Templates\templates\WebApiTemplate\WebApiTemplate.csproj` to `BoltOn` `0.18.1` from `0.18.0`

[BoltOn 0.18.1 on NuGet.org](https://www.nuget.org/packages/BoltOn/0.18.1)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
