### PR TITLE
Moved repository interfaces to DataAbstractions folder

### DIFF
--- a/src/BoltOn.Data.EF/QueryRepository.cs
+++ b/src/BoltOn.Data.EF/QueryRepository.cs
@@ -5,6 +5,7 @@ using System.Linq.Expressions;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore;
+using BoltOn.DataAbstractions.EF;
 
 namespace BoltOn.Data.EF
 {

--- a/src/BoltOn.Data.EF/Repository.cs
+++ b/src/BoltOn.Data.EF/Repository.cs
@@ -5,6 +5,8 @@ using System.Linq.Expressions;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore;
+using BoltOn.DataAbstractions.EF;
+
 
 namespace BoltOn.Data.EF
 {

--- a/src/BoltOn.Data.MartenDb/QueryRepository.cs
+++ b/src/BoltOn.Data.MartenDb/QueryRepository.cs
@@ -5,6 +5,7 @@ using System.Linq.Expressions;
 using System.Threading.Tasks;
 using Marten;
 using System.Linq;
+using BoltOn.DataAbstractions.MartenDb;
 
 namespace BoltOn.Data.MartenDb
 {

--- a/src/BoltOn.Data.MartenDb/Repository.cs
+++ b/src/BoltOn.Data.MartenDb/Repository.cs
@@ -5,6 +5,7 @@ using System.Linq.Expressions;
 using System.Threading.Tasks;
 using Marten;
 using System.Linq;
+using BoltOn.DataAbstractions.MartenDb;
 
 namespace BoltOn.Data.MartenDb
 {

--- a/src/BoltOn/BoltOn.csproj
+++ b/src/BoltOn/BoltOn.csproj
@@ -32,10 +32,18 @@
     <Folder Include="Utilities\" />
     <Folder Include="Other\" />
     <Folder Include="Bus\" />
+    <Folder Include="DataAbstractions\" />
+    <Folder Include="DataAbstractions\EF\" />
+    <Folder Include="DataAbstractions\MartenDb\" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="7.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="7.0.0" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Remove="Data\" />
+    <None Remove="Data\EF\" />
+    <None Remove="DataAbstractions\MartenDb\" />
   </ItemGroup>
 </Project>

--- a/src/BoltOn/DataAbstractions/EF/IQueryRepository.cs
+++ b/src/BoltOn/DataAbstractions/EF/IQueryRepository.cs
@@ -4,7 +4,7 @@ using System.Linq.Expressions;
 using System.Threading;
 using System.Threading.Tasks;
 
-namespace BoltOn.Data.EF
+namespace BoltOn.DataAbstractions.EF
 {
     public interface IQueryRepository<TEntity> where TEntity : class
     {

--- a/src/BoltOn/DataAbstractions/EF/IRepository.cs
+++ b/src/BoltOn/DataAbstractions/EF/IRepository.cs
@@ -1,16 +1,15 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 
-namespace BoltOn.Data.MartenDb
+namespace BoltOn.DataAbstractions.EF
 {
-	public interface IRepository<TEntity> : IQueryRepository<TEntity>
+    public interface IRepository<TEntity> : IQueryRepository<TEntity>
        where TEntity : class
     {
         Task<TEntity> AddAsync(TEntity entity, CancellationToken cancellationToken = default);
         Task<IEnumerable<TEntity>> AddAsync(IEnumerable<TEntity> entities, CancellationToken cancellationToken = default);
         Task UpdateAsync(TEntity entity, CancellationToken cancellationToken = default);
         Task DeleteAsync(object id, CancellationToken cancellationToken = default);
-        Task<object[]> StoreAsync(CancellationToken cancellationToken = default, params object[] objects);
     }
 }

--- a/src/BoltOn/DataAbstractions/MartenDb/IQueryRepository.cs
+++ b/src/BoltOn/DataAbstractions/MartenDb/IQueryRepository.cs
@@ -4,7 +4,7 @@ using System.Linq.Expressions;
 using System.Threading;
 using System.Threading.Tasks;
 
-namespace BoltOn.Data.MartenDb
+namespace BoltOn.DataAbstractions.MartenDb
 {
     public interface IQueryRepository<TEntity> where TEntity : class
     {

--- a/src/BoltOn/DataAbstractions/MartenDb/IRepository.cs
+++ b/src/BoltOn/DataAbstractions/MartenDb/IRepository.cs
@@ -1,15 +1,16 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 
-namespace BoltOn.Data.EF
+namespace BoltOn.DataAbstractions.MartenDb
 {
-    public interface IRepository<TEntity> : IQueryRepository<TEntity>
+	public interface IRepository<TEntity> : IQueryRepository<TEntity>
        where TEntity : class
     {
         Task<TEntity> AddAsync(TEntity entity, CancellationToken cancellationToken = default);
         Task<IEnumerable<TEntity>> AddAsync(IEnumerable<TEntity> entities, CancellationToken cancellationToken = default);
         Task UpdateAsync(TEntity entity, CancellationToken cancellationToken = default);
         Task DeleteAsync(object id, CancellationToken cancellationToken = default);
+        Task<object[]> StoreAsync(CancellationToken cancellationToken = default, params object[] objects);
     }
 }

--- a/tests/BoltOn.Tests/Data/EF/Fakes/EFRegistrationTask.cs
+++ b/tests/BoltOn.Tests/Data/EF/Fakes/EFRegistrationTask.cs
@@ -4,6 +4,7 @@ using BoltOn.Data.EF;
 using BoltOn.Tests.Other;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
+using BoltOn.DataAbstractions.EF;
 
 namespace BoltOn.Tests.Data.EF.Fakes
 {

--- a/tests/BoltOn.Tests/Data/EF/Fakes/EFRepositoryFixture.cs
+++ b/tests/BoltOn.Tests/Data/EF/Fakes/EFRepositoryFixture.cs
@@ -3,6 +3,7 @@ using BoltOn.Data;
 using BoltOn.Data.EF;
 using BoltOn.Tests.Other;
 using Microsoft.Extensions.DependencyInjection;
+using BoltOn.DataAbstractions.EF;
 
 namespace BoltOn.Tests.Data.EF.Fakes
 {

--- a/tests/BoltOn.Tests/Data/MartenDb/Fakes/MartenDbRepositoryFixture.cs
+++ b/tests/BoltOn.Tests/Data/MartenDb/Fakes/MartenDbRepositoryFixture.cs
@@ -3,6 +3,7 @@ using BoltOn.Data.MartenDb;
 using BoltOn.Tests.Other;
 using Marten;
 using Microsoft.Extensions.DependencyInjection;
+using BoltOn.DataAbstractions.MartenDb;
 
 namespace BoltOn.Tests.Data.MartenDb.Fakes
 {

--- a/tests/BoltOn.Tests/Data/MartenDb/RepositoryTests.cs
+++ b/tests/BoltOn.Tests/Data/MartenDb/RepositoryTests.cs
@@ -10,6 +10,7 @@ using BoltOn.Tests.Other;
 using Xunit;
 using Student = BoltOn.Tests.Data.MartenDb.Fakes.Student;
 using Microsoft.Extensions.DependencyInjection;
+using BoltOn.DataAbstractions.MartenDb;
 
 namespace BoltOn.Tests.Data.MartenDb
 {

--- a/tests/BoltOn.Tests/Other/StudentRepository.cs
+++ b/tests/BoltOn.Tests/Other/StudentRepository.cs
@@ -1,5 +1,6 @@
 using BoltOn.Data;
 using BoltOn.Data.EF;
+using BoltOn.DataAbstractions.EF;
 
 namespace BoltOn.Tests.Other
 {

--- a/tests/BoltOn.Tests/Requestor/Fakes/AddStudentHandler.cs
+++ b/tests/BoltOn.Tests/Requestor/Fakes/AddStudentHandler.cs
@@ -3,6 +3,7 @@ using System.Threading.Tasks;
 using BoltOn.Data.EF;
 using BoltOn.Requestor;
 using BoltOn.Tests.Other;
+using BoltOn.DataAbstractions.EF;
 
 namespace BoltOn.Tests.Requestor.Fakes
 {


### PR DESCRIPTION
Moved EF's and MartenDb's repository interfaces to the DataAbstractions folder in the core BoltOn 